### PR TITLE
fix issue #55 missing User-Agent header in API calls and issue #58 getFill API change

### DIFF
--- a/src/main/java/com/coinbase/exchange/api/exchange/GdaxExchangeImpl.java
+++ b/src/main/java/com/coinbase/exchange/api/exchange/GdaxExchangeImpl.java
@@ -137,6 +137,7 @@ public class GdaxExchangeImpl implements GdaxExchange {
 
         headers.add("accept", "application/json");
         headers.add("content-type", "application/json");
+        headers.add("User-Agent", "gdax-java unofficial coinbase pro api library");
         headers.add("CB-ACCESS-KEY", publicKey);
         headers.add("CB-ACCESS-SIGN", signature.generate(resource, method, jsonBody, timestamp));
         headers.add("CB-ACCESS-TIMESTAMP", timestamp);

--- a/src/main/java/com/coinbase/exchange/api/orders/OrderService.java
+++ b/src/main/java/com/coinbase/exchange/api/orders/OrderService.java
@@ -23,6 +23,7 @@ public class OrderService {
     GdaxExchange exchange;
 
     public static final String ORDERS_ENDPOINT = "/orders";
+    public static final String FILLS_ENDPOINT = "/fills";
 
     public List<Hold> getHolds(String accountId) {
         return exchange.getAsList(ORDERS_ENDPOINT + "/" + accountId + "/holds", new ParameterizedTypeReference<Hold[]>(){});
@@ -53,9 +54,12 @@ public class OrderService {
         return Arrays.asList(exchange.delete(ORDERS_ENDPOINT, new ParameterizedTypeReference<Order[]>(){}));
     }
 
-    public List<Fill> getAllFills() {
-        String fillsEndpoint = "/fills";
-        return exchange.getAsList(fillsEndpoint, new ParameterizedTypeReference<Fill[]>(){});
+    public List<Fill> getFillsByProductId(String product_id, int resultLimit) {
+        return exchange.getAsList(FILLS_ENDPOINT + "?product_id=" + product_id + "&limit=" + resultLimit, new ParameterizedTypeReference<Fill[]>(){});
+    }
+    
+    public List<Fill> getFillByOrderId(String order_id, int resultLimit) {
+        return exchange.getAsList(FILLS_ENDPOINT + "?order_id=" + order_id + "&limit=" + resultLimit, new ParameterizedTypeReference<Fill[]>(){});
     }
 }
 

--- a/src/test/java/com/coinbase/exchange/api/orders/OrderTests.java
+++ b/src/test/java/com/coinbase/exchange/api/orders/OrderTests.java
@@ -102,10 +102,29 @@ public class OrderTests extends BaseTest {
     }
 
     @Test
-    public void getFills() {
-        List<Fill> fills = orderService.getAllFills();
+    public void getFillsByProductId() {
+        List<Fill> fills = orderService.getFillsByProductId("BTC-USD", 100);
         assertTrue(fills.size() >= 0);
     }
+
+    @Test
+    public void createMarketOrderBuyThenGetFillByOrderId() {
+        NewMarketOrderSingle marketOrder = createNewMarketOrder("BTC-USD", "buy", new BigDecimal(0.01));
+        Order order = orderService.createOrder(marketOrder);
+
+        assertTrue(order != null); //make sure we created an order
+        String orderId = order.getId();
+        assertTrue(orderId.length() > 0); //ensure we have an actual orderId
+        Order filledOrder = orderService.getOrder(orderId);
+        assertTrue(filledOrder != null); //ensure our order hit the system
+        assertTrue(new BigDecimal(filledOrder.getSize()).compareTo(BigDecimal.ZERO) > 0); //ensure we got a fill
+        log.info("Order opened and filled: " + filledOrder.getSize() + " @ " + filledOrder.getExecuted_value()
+             + " at the cost of " + filledOrder.getFill_fees());
+        
+        List<Fill> fills = orderService.getFillByOrderId(orderId, 100);
+        assertTrue(fills.size() >= 0);
+    }
+    
     @Test
     public void createMarketOrderBuy(){
         NewMarketOrderSingle marketOrder = createNewMarketOrder("BTC-USD", "buy", new BigDecimal(0.01));

--- a/src/test/java/com/coinbase/exchange/api/orders/OrderTests.java
+++ b/src/test/java/com/coinbase/exchange/api/orders/OrderTests.java
@@ -108,21 +108,11 @@ public class OrderTests extends BaseTest {
     }
 
     @Test
-    public void createMarketOrderBuyThenGetFillByOrderId() {
+    public void shouldGetFilledByOrderIdWhenMakingMarketOrderBuy() { 
         NewMarketOrderSingle marketOrder = createNewMarketOrder("BTC-USD", "buy", new BigDecimal(0.01));
         Order order = orderService.createOrder(marketOrder);
-
-        assertTrue(order != null); //make sure we created an order
-        String orderId = order.getId();
-        assertTrue(orderId.length() > 0); //ensure we have an actual orderId
-        Order filledOrder = orderService.getOrder(orderId);
-        assertTrue(filledOrder != null); //ensure our order hit the system
-        assertTrue(new BigDecimal(filledOrder.getSize()).compareTo(BigDecimal.ZERO) > 0); //ensure we got a fill
-        log.info("Order opened and filled: " + filledOrder.getSize() + " @ " + filledOrder.getExecuted_value()
-             + " at the cost of " + filledOrder.getFill_fees());
-        
-        List<Fill> fills = orderService.getFillByOrderId(orderId, 100);
-        assertTrue(fills.size() >= 0);
+        List<Fill> fills = orderService.getFillByOrderId(order.getId(), 100);
+        assertTrue(fills.size() == 1);
     }
     
     @Test


### PR DESCRIPTION
Fixes issue where cloudflare blocks API requests with no User-Agent header.  Based on the comment by alistairrutherford, the value of the User-Agent does not seem to matter, as long as it's present.

"Access denied | api-public.sandbox.pro.coinbase.com used Cloudflare to restrict access"